### PR TITLE
Fixed bug. Printing the help message caused the program to crash.

### DIFF
--- a/src/app/core.clj
+++ b/src/app/core.clj
@@ -65,7 +65,7 @@
           (System/exit 0)))
       (when (:help opts)
         (do
-          (println ("Printing help message, as asked"))
+          (println "Printing help message, as asked")
           (println banner))
         (System/exit 0))
       (if


### PR DESCRIPTION
Executing lein run -- --help caused an error: 
Exception in thread "main" java.lang.ClassCastException: java.lang.String cannot be cast to clojure.lang.IFn, compiling:(/tmp/form-init2598538132899288652.clj:1:72)

